### PR TITLE
Mzieg test

### DIFF
--- a/SPI/spi_console.py
+++ b/SPI/spi_console.py
@@ -538,13 +538,13 @@ class cCfgCombo:
         self.stringVar.set(str(self.value))
             
     def SPIWrite(self):
-        # send_command(SPI=self.SPI, ready=self.ready, address=self.address, value=self.value, write_len=self.write_len, name=self.name)
+        send_command(SPI=self.SPI, ready=self.ready, address=self.address, value=self.value, write_len=self.write_len, name=self.name)
 
-        unbuffered_cmd = fixCRC([START, 0, self.write_len, self.address | WRITE, self.value, CRC, END])
-        buffered_response = bytearray(len(unbuffered_cmd) + WRITE_RESPONSE_OVERHEAD + self.write_len - 1)  # MZ: kludge (added -1, same as required for cCfgEntry.SPIWrite)
-        buffered_cmd = buffer_bytearray(unbuffered_cmd, len(buffered_response))
-        with lock:
-            SPI.write_readinto(buffered_cmd, buffered_response) 
+        # unbuffered_cmd = fixCRC([START, 0, self.write_len, self.address | WRITE, self.value, CRC, END])
+        # buffered_response = bytearray(len(unbuffered_cmd) + WRITE_RESPONSE_OVERHEAD + self.write_len - 1)  # MZ: kludge (added -1, same as required for cCfgEntry.SPIWrite)
+        # buffered_cmd = buffer_bytearray(unbuffered_cmd, len(buffered_response))
+        # with lock:
+        #     SPI.write_readinto(buffered_cmd, buffered_response) 
 
     def Update(self, force=False):
         newValue = 0

--- a/SPI/spi_console.py
+++ b/SPI/spi_console.py
@@ -113,7 +113,7 @@ def parseArgs(argv):
     parser.add_argument("--test-ramp-incr",      type=int,              default=1,          help="increment ramp at this integration time")
     parser.add_argument("--stomp-first",         type=int,              default=0,          help="stomp this many pixels at front of spectrum")
     parser.add_argument("--excitation-nm",       type=float,            default=0,          help="laser excitation wavelength (used to generate wavenumber axis)")
-    parser.add_argument("--graph",               type=bool,             default=True,       help="use --nograph to disable")
+    parser.add_argument("--graph",               type=bool,             default=True,       help="graph each spectrum (--no-graph to disable)", action=argparse.BooleanOptionalAction)
     parser.add_argument("--paused",              action="store_true",   help="launch with acquisition paused")
     parser.add_argument("--debug",               action="store_true",   help="output verbose debug messages")
     return parser.parse_args(argv[1:])
@@ -1040,7 +1040,7 @@ class cWinMain(tk.Tk):
         if self.acquireActive:
             self.after(args.delay_ms, self.Acquire)
 
-        return spectrum # for Test
+        return spectrum # for test()
 
     def FPGAInit(self):
         debug("performing FPGA Init")


### PR DESCRIPTION
Added new "Test" button which is only available if you run with --paused.

Basically this button will run a unit through a predefined test sequence which includes reading the EEPROM, rendering the wavecal (in wavenumbers if excitation provided), collecting a set of 20 spectra at the minimum integration time, then collecting a second set of spectra as integration time is ramped across the range of interest.  At the end of the test, a report is written as a single CSV containing all measurements, as well as all runtime arguments and key EEPROM settings, plus summary timing metrics.

There are currently no pass-fail criteria (the test doesn't report "success" or "failure").  The idea is to use this to collect a set of "expected similar" data from a swath of units and then make a human judgement as to whether they are sufficiently close to constitute passage.

Key enhancements in this branch include:
- the ability to not only read the EEPROM as hex, but to parse-out key fields like serial number and wavecal
- the ability to reliably take spectra after reading the EEPROM (not just "read spectra," but spectra that looks the same as if you hadn't read the EEPROM, which proved the tricky bit)

Key learnings:
- undocumented opcodes matter