### PR TITLE
Bauz bswap

### DIFF
--- a/fpga/greg-util.py
+++ b/fpga/greg-util.py
@@ -92,7 +92,7 @@ class RegisterUtil(tk.Tk):
         REG_D2			0x00D2		0x0000		IMX Control/Status
         REG_D3			0x00D3		0x0000		BLE Control/Status
         REG_D4			0x00D4		0xD4D4		Spare
-        REG_D5			0x00D5		0xD4D4		Spare
+        REG_D5			0x00D5		0xD5D5		Spare
         REG_D6			0x00D6      0x0000		FIFO RD Pointer
         REG_D7			0x00D7		0x0000		FIFO WR Pointer
     """

--- a/fpga/greg-util.py
+++ b/fpga/greg-util.py
@@ -192,14 +192,9 @@ class RegisterUtil(tk.Tk):
     def write(self, addr, val):
         """ writes values into fpga register """
         val = self.bswap_int(val)
-        if not offline_mode:
-            buf = usb.util.create_buffer(4)
-            bmReqType = usb.util.build_request_type(usb.util.CTRL_IN, usb.util.CTRL_TYPE_VENDOR,usb.util.CTRL_RECIPIENT_DEVICE)
-            self.dev.ctrl_transfer(bmReqType, 0x91, addr, val, buf)
-        else:
-            # in offline mode, fake a memset in internal memory
-            offline_mem[2*addr] = int(s[0:2], 16)
-            offline_mem[2*addr+1] = int(s[2:4], 16)
+        buf = usb.util.create_buffer(4)
+        bmReqType = usb.util.build_request_type(usb.util.CTRL_IN, usb.util.CTRL_TYPE_VENDOR,usb.util.CTRL_RECIPIENT_DEVICE)
+        self.dev.ctrl_transfer(bmReqType, 0x91, addr, val, buf)            
         
     ############################################################################
     # event callbacks
@@ -223,7 +218,12 @@ class RegisterUtil(tk.Tk):
 
         print(f"writing {name} 0x{addr:04x} <- 0x{value:04x} ({desc})")
 
-        self.write(addr, value)
+        if not offline_mode:
+            self.write(addr, value)
+        else:
+            # in offline mode, fake a memset in internal memory
+            offline_mem[2*addr] = int(s[0:2], 16)
+            offline_mem[2*addr+1] = int(s[2:4], 16)
 
     def textbox_write_backspace(self, event):
         insert_index = self.textbox_write.index("insert")


### PR DESCRIPTION
the FPGA deals in MSB (big endian, network byte order) for both read and write
the ARM translates the LSB (little endian) address generated on the intel platform but does not translate the data
the greg utility must translate the data upon read, and before writing to display in the expected order

this chain will be defined in the in-process docs for the GLA, for now this works.